### PR TITLE
Add all self links to resources

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent {
         docker {
             label 'docker'
-            image 'gradle:4.6.0-jdk8-alpine'
+            image 'gradle:4.10.3-jdk8-alpine'
         }
     }
     stages {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'com.jfrog.bintray' version '1.8.4'
-    id 'com.github.ben-manes.versions' version '0.20.0'
+    id 'com.jfrog.bintray' version '1.8.0'
+    id 'com.github.ben-manes.versions' version '0.17.0'
     id 'com.github.kt3k.coveralls' version '2.8.2'
 }
 
@@ -25,14 +25,14 @@ repositories {
 }
 
 
-apply from: 'https://raw.githubusercontent.com/FINTlibs/fint-buildscripts/v1.8.0/dependencies.gradle'
+apply from: 'https://raw.githubusercontent.com/FINTlibs/fint-buildscripts/v1.3.0/dependencies.gradle'
 dependencies {
-    compile('no.fint:fint-model-resource:0.3.3')
+    compile('no.fint:fint-model-resource:0.3.2')
     compile('no.fint:fint-relation-model:1.1.5')
 
     compile("com.github.springfox.loader:springfox-loader:${springfoxLoaderVersion}")
     compile("org.projectlombok:lombok:${lombokVersion}")
-    compile('org.apache.commons:commons-text:1.8')
+    compile('org.apache.commons:commons-text:1.3')
 
     compile('org.springframework.hateoas:spring-hateoas:0.24.0.RELEASE')
     compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
@@ -60,5 +60,5 @@ test {
 }
 
 if (project.hasProperty('bintrayUser') && project.hasProperty('bintrayKey')) {
-    apply from: 'https://raw.githubusercontent.com/FINTlibs/fint-buildscripts/v1.8.0/bintray.gradle'
+    apply from: 'https://raw.githubusercontent.com/FINTlibs/fint-buildscripts/v1.3.0/bintray.gradle'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'com.jfrog.bintray' version '1.8.0'
-    id 'com.github.ben-manes.versions' version '0.17.0'
+    id 'com.jfrog.bintray' version '1.8.4'
+    id 'com.github.ben-manes.versions' version '0.20.0'
     id 'com.github.kt3k.coveralls' version '2.8.2'
 }
 
@@ -25,14 +25,14 @@ repositories {
 }
 
 
-apply from: 'https://raw.githubusercontent.com/FINTlibs/fint-buildscripts/v1.3.0/dependencies.gradle'
+apply from: 'https://raw.githubusercontent.com/FINTlibs/fint-buildscripts/v1.8.0/dependencies.gradle'
 dependencies {
-    compile('no.fint:fint-model-resource:0.3.2')
+    compile('no.fint:fint-model-resource:0.3.3')
     compile('no.fint:fint-relation-model:1.1.5')
 
     compile("com.github.springfox.loader:springfox-loader:${springfoxLoaderVersion}")
     compile("org.projectlombok:lombok:${lombokVersion}")
-    compile('org.apache.commons:commons-text:1.3')
+    compile('org.apache.commons:commons-text:1.8')
 
     compile('org.springframework.hateoas:spring-hateoas:0.24.0.RELEASE')
     compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
@@ -60,5 +60,5 @@ test {
 }
 
 if (project.hasProperty('bintrayUser') && project.hasProperty('bintrayKey')) {
-    apply from: 'https://raw.githubusercontent.com/FINTlibs/fint-buildscripts/v1.3.0/bintray.gradle'
+    apply from: 'https://raw.githubusercontent.com/FINTlibs/fint-buildscripts/v1.8.0/bintray.gradle'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/no/fint/relations/FintLinker.java
+++ b/src/main/java/no/fint/relations/FintLinker.java
@@ -31,13 +31,14 @@ public abstract class FintLinker<T extends FintLinks> {
 
     public T toResource(T resource) {
         mapLinks(resource);
-        if (resource.getSelfLinks() == null || resource.getSelfLinks().isEmpty()) {
-            getAllSelfHrefs(resource)
-                    .filter(StringUtils::isNotBlank)
-                    .map(linkMapper::populateProtocol)
-                    .map(Link::with)
-                    .forEach(link -> resource.addLink("self", link));
+        if (resource.getSelfLinks() != null) {
+            resource.getSelfLinks().clear();
         }
+        getAllSelfHrefs(resource)
+                .filter(StringUtils::isNotBlank)
+                .map(linkMapper::populateProtocol)
+                .map(Link::with)
+                .forEach(resource::addSelf);
 
         return resource;
     }


### PR DESCRIPTION
This PR introduces a new method `getAllSelfHrefs(R)` to `FintLinker`, returning `Stream<String>` of all `self` links to resources.

By default it produces a single element, delegating to `getSelfHref(R)`, but this can be overridden.

The `toResource(R)` method uses this new method to include all self hrefs in the resources.